### PR TITLE
Edit and submit snowflake classification reports

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -51,12 +51,61 @@ st.markdown(
     /* Full screen data editor styles */
     .stDataFrame {
         width: 100% !important;
-        height: 70vh !important;
+        height: 90vh !important;
+        min-height: 90vh !important;
     }
     
     .stDataFrame > div {
         width: 100% !important;
-        height: 70vh !important;
+        height: 90vh !important;
+        min-height: 90vh !important;
+    }
+    
+    /* Make sure the data editor fills the container */
+    div[data-testid="stDataFrame"] {
+        width: 100% !important;
+        height: 90vh !important;
+        min-height: 90vh !important;
+    }
+    
+    div[data-testid="stDataFrame"] > div {
+        width: 100% !important;
+        height: 90vh !important;
+        min-height: 90vh !important;
+    }
+    
+    /* Additional targeting for the data editor component */
+    .stDataFrame div[data-testid="stDataFrameContainer"] {
+        width: 100% !important;
+        height: 90vh !important;
+    }
+    
+    /* Override any margin constraints */
+    .main .block-container {
+        padding-top: 1rem;
+        padding-bottom: 1rem;
+        padding-left: 2rem;
+        padding-right: 2rem;
+        max-width: none;
+        width: 98vw;
+    }
+    
+    /* Make the data editor container larger */
+    .stContainer {
+        width: 100% !important;
+    }
+    
+    /* Ensure tables use full width */
+    .stDataFrame table {
+        width: 100% !important;
+        min-width: 100% !important;
+    }
+    
+    /* Style the data editor to be more prominent */
+    div[data-testid="stDataFrame"] iframe {
+        width: 100% !important;
+        height: 90vh !important;
+        min-height: 90vh !important;
     }
     
     /* Auto-save indicator styles */
@@ -1524,12 +1573,14 @@ if app_mode == "Classifications":
             st.session_state.edited_df['INFOSEC_APPROVAL_STATUS'] = st.session_state.edited_df['INFOSEC_APPROVAL_STATUS'].cat.set_categories(['MASK', 'APPROVED', 'NO MASKING NEEDED'])
 
             # Create the data editor with full screen height and auto-save
-            with st.container():
+            # Use columns to maximize width usage
+            col1, col2, col3 = st.columns([0.02, 0.96, 0.02])
+            with col2:
                 edited_df = st.data_editor(
                     st.session_state.edited_df, 
                     num_rows="dynamic", 
                     use_container_width=True,
-                    height=600,  # Fixed height for better full-screen experience
+                    height=1000,  # Maximum height for better full-screen experience
                     key=f"data_editor_{st.session_state.auto_save_key}"
                 )
 


### PR DESCRIPTION
Increase data editor size to fill the page for improved classification report editing.

The data editor now utilizes more screen real estate by adjusting CSS properties for height and width, and by setting the `st.data_editor` component's height to 1000px, providing a more comprehensive view of the classification report.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e397d5c-05a9-453f-a6e9-abbb0ee4dac2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e397d5c-05a9-453f-a6e9-abbb0ee4dac2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

